### PR TITLE
volume float to fixed

### DIFF
--- a/src/native/cef/util/player.js
+++ b/src/native/cef/util/player.js
@@ -218,7 +218,7 @@ var f = function() {
     _proPlayer._$stepVolume = function(_flag){
         var _vol = _n._$exec('player.getVolume')+(_flag||0)*this.__step;
         this._$setVolume(
-            Math.max(0,Math.min(1,_vol))
+            Math.max(0,Math.min(1,_vol.toFixed(2)))
         );
     };
     /**


### PR DESCRIPTION
float数字有精度误差，最后产生一个0.0000000000000138这种数字，native又会把音量射程0.1，于是永远都不能到达0
