### PR TITLE
解决“使用util/ajax/xdr发送POST请求时，数据无法正确传递”的问题

### DIFF
--- a/src/util/ajax/proxy/xhr.js
+++ b/src/util/ajax/proxy/xhr.js
@@ -105,6 +105,9 @@ NEJ.define([
                     });
                 }
             }
+            if(_headers[_g._$HEAD_CT]===_g._$HEAD_CT_FORM){
+                _request.data = _u._$object2string(_request.data, '&');
+            }
             // state change
             this.__xhr.onreadystatechange = 
                 this.__onStateChange._$bind(this,2);


### PR DESCRIPTION
convert data from object to FormData-string when Content-Type=application/x-www-form-urlencoded

如题。ajax请求最后在发出前，xhr.send(data)传入的参数会被转换为字符串，一般使用_$request方法时传入的data属性是简单的对象类型，所以最后请求的数据部分成了“[object, object]”，造成后台无法获取数据，请求失败。

本次改动，就是对这个问题进行了处理。详情可以看：http://www.shhider.com/blog/2015/07/NEJ-studying/