### PR TITLE
Fix: uncaught error in clearListInCache at util/cache/list

### DIFF
--- a/src/util/cache/list.js
+++ b/src/util/cache/list.js
@@ -753,7 +753,7 @@ NEJ.define([
             _list.splice(_index,1);
         };
         return function(_key){
-            if (!!_key){
+            if (_u._$isString(_key)){
                 // clear one list
                 var _list = this._$getListInCache(_key);
                 _u._$reverseEach(_list,_doClear);


### PR DESCRIPTION
重现方法：

1. 实例化一个列表缓存管理器；
2. 调用``_$getListCache``方法或其他会调用``_$getListCache``的方法，不指定列表标识；
3. 调用``_$clearListInCache``方法，参数为空；
4. 页面执行后报错：“Maximum call stack size exceeded”。

原因：

调用``_$getListCache``方法时，若没有指定列表标识，方法会在缓存结构中添加名为``list``的列表（正常的应该是``xxx-list``）。

参数为空执行``_$clearListInCache``方法时，它的功能是清除所有数据列表。执行逻辑是遍历缓存结构中的列表，截取列表名称、获得列表标识后再单独调用``_$clearListInCache``。

此时，若取到列表名称为``list``的列表，截取结果是空字符串，再执行``_$clearListInCache``时就会造成循环。

解决方案：

修改``_$clearListInCache``方法，接受字符串类型的参数为合法的列表标识（包括空字符串），类型的参数都判定为清除所有数据列表。

```javascript
-            if (!!_key){
+           if (_u._$isString(_key)){
```