### PR TITLE
bugfix ajax/tag _$loadTemplate

### DIFF
--- a/src/util/ajax/tag.js
+++ b/src/util/ajax/tag.js
@@ -229,7 +229,7 @@ NEJ.define([
         }else{
             var callback = _options.onload;
             _options.onload = function(event){
-                callback(e._$html2node(event.content));
+                callback(e._$html2node(event && event.content));
             };
             _p._$loadText(_url, _options);
         }


### PR DESCRIPTION
当第二次加载存在缓存时，loader dispatchEvent('onload')，此时 event 为空， _$loadTempate 执行回调时直接读取 event.content 会抛出异常。